### PR TITLE
Fix android redirect for relative location headers

### DIFF
--- a/android/src/network/NetworkRequest.java
+++ b/android/src/network/NetworkRequest.java
@@ -1507,7 +1507,7 @@ public class NetworkRequest implements com.naef.jnlua.NamedJavaFunction
 							System.out.println("WARNING: " + String.format("redirecting from HTTPS to HTTP (%s -> %s)", origURL, locHeader));
 						}
 
-						URL url = new URL(locHeader);
+						URL url = new URL(urlConnection.getURL(), locHeader);
 
 						debug("Handling %d redirect to: %s", responseCode, locHeader);
 


### PR DESCRIPTION
This addresses #1 and also the error message from https://github.com/coronalabs/corona/issues/201#issue-759033744 though it was not related to query strings so there may be other issues present.

I was unfortunately unable to get this building on my windows machine to test this fix but if you are able to build this it should be a simple matter of building the debug project listed in https://github.com/coronalabs/corona/issues/201#issue-759033744 and then running it on the android emulator bundled with android studio. I verified the error message is showing up there by using `logcat` to view the device terminal.