### PR TITLE
Windows: enlarge buffer size for greater throughput

### DIFF
--- a/win32/WinHttpAsyncRequestSessionData.h
+++ b/win32/WinHttpAsyncRequestSessionData.h
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
-// This file is part of the Corona game engine.
+// This file is part of the Solar2D game engine.
+// With contributions from Dianchu Technology
 // For overview and more information on licensing please refer to README.md 
 // Home page: https://github.com/coronalabs/corona
 // Contact: support@coronalabs.com
@@ -15,8 +16,8 @@
 
 #include "WindowsNetworkSupport.h"
 
-#define SESSION_TX_BUFFER_SIZE 8192
-#define SESSION_RX_BUFFER_SIZE 8192 // As recommended by Microsoft's WinHttp documentation
+#define SESSION_TX_BUFFER_SIZE 262144
+#define SESSION_RX_BUFFER_SIZE 262144 // Orignal 8192 was recommended by Microsoft's WinHttp documentation, has 4.4Mbps download speed at maximum.
 
 /// Stores information needed by a threaded HTTP request.
 /// Provides fields to be monitored by the main thread to control the async operation.


### PR DESCRIPTION
The Windows network API uses a polling mechanism (instead of the asynchronous callbacks of other platforms) and an 8KB buffer size, resulting in an upper limit of about 4.4Mbps.

With stability as the main focus, simply increasing the buffer size can meet the requirements for throughput. By adjusting the buffer size to 256KB, it can meet a download rate/throughput of about 100Mbps. This makes Windows perform consistently with Mac, iOS, and Android on a 100Mbps bandwidth.

The side effect is that the frequency of the [progress](https://docs.coronalabs.com/api/event/networkRequest/phase.html) event callbacks for large file downloads (generally larger than 1MB) is reduced, because it takes longer to fill the buffer. There is no impact on regular HTTP requests (a few KB).

Links: [WinHttpReadData function (winhttp.h) Remarks](https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpreaddata#remarks)
